### PR TITLE
[fix] 이력서 도메인 API 개발로 인한 AI 기업 매칭 기능 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -264,3 +264,5 @@ poetry.toml
 pyrightconfig.json
 
 # End of https://www.toptal.com/developers/gitignore/api/python,pycharm
+
+.DS_Store

--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 from pydantic import BaseModel
+from starlette.responses import JSONResponse
 
 from recommend_jobs import recommend_jobs_by_resume_id
 
@@ -7,10 +8,13 @@ app = FastAPI()
 
 
 class RecommendationByResumeIdRequest(BaseModel):
-    resumeId: str
+    resume_id: str
 
 
 @app.post("/recommend")
 def recommend_by_resume_id(data: RecommendationByResumeIdRequest):
-    recommendations = recommend_jobs_by_resume_id(data.resumeId)
-    return recommendations
+    try:
+        recommendations = recommend_jobs_by_resume_id(data.resume_id)
+        return JSONResponse(content={"status": "성공", "data": recommendations})
+    except Exception as e:
+        return JSONResponse(content={"status": "실패", "data": [], "error": str(e)})

--- a/app.py
+++ b/app.py
@@ -1,18 +1,19 @@
 from fastapi import FastAPI
 from pydantic import BaseModel
-from typing import List
 
-from recommend_jobs import recommend_jobs
+from recommend_jobs import recommend_jobs_by_resume_id
 
 app = FastAPI()
 
 
-class RecommendationRequest(BaseModel):
-    userStacks: List[str]
-    userResume: str
+class RecommendationByResumeIdRequest(BaseModel):
+    resumeId: str
 
 
 @app.post("/recommend")
-def recommend_endpoint(data: RecommendationRequest):
-    recommendations = recommend_jobs(data.userStacks, data.userResume)
-    return recommendations
+def recommend_by_resume_id(data: RecommendationByResumeIdRequest):
+    try:
+        recommendations = recommend_jobs_by_resume_id(data.resumeId)
+        return {"status": "성공", "data": recommendations}
+    except Exception as e:
+        return {"status": "에러", "message": str(e)}

--- a/app.py
+++ b/app.py
@@ -12,8 +12,5 @@ class RecommendationByResumeIdRequest(BaseModel):
 
 @app.post("/recommend")
 def recommend_by_resume_id(data: RecommendationByResumeIdRequest):
-    try:
-        recommendations = recommend_jobs_by_resume_id(data.resumeId)
-        return {"status": "성공", "data": recommendations}
-    except Exception as e:
-        return {"status": "에러", "message": str(e)}
+    recommendations = recommend_jobs_by_resume_id(data.resumeId)
+    return recommendations

--- a/crawler.py
+++ b/crawler.py
@@ -109,7 +109,7 @@ try:
             try:
                 button = WebDriverWait(driver, 5).until(
                     EC.element_to_be_clickable(
-                        (By.CSS_SELECTOR, ".JobDescription_JobDescription__paragraph__wrapper__G4CNd button"))
+                        (By.CSS_SELECTOR, ".JobDescription_JobDescription__paragraph__wrapper__WPrKC button"))
                 )
                 button.click()
                 time.sleep(2)
@@ -117,18 +117,18 @@ try:
                 pass  # '더 보기' 버튼이 없어도 진행
 
             company_name = driver.find_element(By.CSS_SELECTOR,
-                                               ".JobHeader_JobHeader__Tools__Company__Link__zAvYv").text
-            location = driver.find_element(By.CSS_SELECTOR, ".JobHeader_JobHeader__Tools__Company__Info__yT4OD").text
+                                               ".JobHeader_JobHeader__Tools__Company__Info__b9P4Y").text
+            location = driver.find_element(By.CSS_SELECTOR, ".JobHeader_JobHeader__Tools__Company__Info__b9P4Y").text
             position_name = WebDriverWait(driver, 10).until(
                 EC.presence_of_element_located((By.CSS_SELECTOR, "h1.wds-jtr30u"))
             ).text
-            experience = driver.find_elements(By.CSS_SELECTOR, ".JobHeader_JobHeader__Tools__Company__Info__yT4OD")[
+            experience = driver.find_elements(By.CSS_SELECTOR, ".JobHeader_JobHeader__Tools__Company__Info__b9P4Y")[
                 -1].text
-            due_date = driver.find_element(By.CSS_SELECTOR, ".JobDueTime_JobDueTime__3yzxa span").text
+            due_date = driver.find_element(By.CSS_SELECTOR, ".JobDueTime_JobDueTime__yvhtg span").text
 
             # ✅ 이미지 URL 추출
             try:
-                image_element = driver.find_element(By.CSS_SELECTOR, ".JobCard_JobCard__thumb__WU1ax img")
+                image_element = driver.find_element(By.CSS_SELECTOR, ".JobCard_JobCard__thumb__iOtFn img")
                 image_url = image_element.get_attribute("src")
             except Exception:
                 image_url = None
@@ -136,9 +136,9 @@ try:
 
             # 상세 내용 추출
             job_detail_wrapper = driver.find_element(By.CSS_SELECTOR,
-                                                     ".JobDescription_JobDescription__paragraph__wrapper__G4CNd")
+                                                     ".JobDescription_JobDescription__paragraph__wrapper__WPrKC")
             paragraphs = job_detail_wrapper.find_elements(By.CSS_SELECTOR,
-                                                          ".JobDescription_JobDescription__paragraph__Lhegj")
+                                                          ".JobDescription_JobDescription__paragraph__87w8I")
             details = [p.find_element(By.CSS_SELECTOR, "span").text.replace("\n", " ").strip() for p in paragraphs if
                        p.text.strip()]
 

--- a/crawler.py
+++ b/crawler.py
@@ -24,7 +24,7 @@ driver = webdriver.Chrome(options=options)
 
 
 def fetch_stacks():
-    query = text("SELECT stack_id, name FROM stack")
+    query = text("SELECT stack_id, name FROM stacks")
     result = session.execute(query).mappings().all()
     return {row['name'].lower(): row['stack_id'] for row in result}
 
@@ -33,7 +33,7 @@ def fetch_stacks():
 # 채용공고 저장 및 매핑 함수
 def save_recruitment_with_tech(company_name, location, position, experience, due_date, image_url, details, tech_stacks):
     insert_recruitment_query = text("""
-        INSERT INTO recruitment (company_name, location, position, career, deadline, image_url, main_task, qualification, preferred, benefit)
+        INSERT INTO recruitments (company_name, location, position, career, deadline, image_url, main_task, qualification, preferred, benefit)
         VALUES (:company_name, :location, :position, :career, :deadline, :image_url, :main_task, :qualification, :preferred, :benefit)
     """)
 

--- a/fetch_resume_document.py
+++ b/fetch_resume_document.py
@@ -1,0 +1,38 @@
+from pymongo import MongoClient
+from bson import ObjectId
+
+MONGO_URL = "mongodb://localhost:27017"
+client = MongoClient(MONGO_URL)
+db = client['devpass']
+resume_collection = db['resume_document']
+
+# 이력서 ID(Object)로 이력서 찾기
+def fetch_resume_document(resume_id: str):
+    return resume_collection.find_one({"_id": ObjectId(resume_id)})
+
+# 이력서에서 유저 기술 스택 추출하기
+def extract_user_stacks(resume: dict) -> list[str]:
+    skills_section = resume.get("skills", [])
+    stacks = set()
+
+    for skill in skills_section:
+        for tech in skill.get("skills", []):
+            stacks.add(tech.strip())
+
+    return list(stacks)
+
+# 기업추천에 사용할 텍스트 만들기
+def convert_resume_to_text(resume: dict) -> str:
+    parts = []
+
+    parts.append(f"요약: {' '.join(resume.get('summary', []))}")
+
+    for exp in resume.get("experience", []):
+        parts.append(f"[프로젝트] {exp.get('project', '')} - {exp.get('summary', '')} ({exp.get('duration', '')})")
+        parts.append(f"기술: {', '.join(exp.get('skills', []))}")
+        parts.append(f"설명: {', '.join(exp.get('description', []))}")
+
+    for act in resume.get("activities", []):
+        parts.append(f"[활동] {act.get('title', '')} ({act.get('duration', '')}) - {act.get('description', '')}")
+
+    return "\n".join(parts)

--- a/fetch_resume_document.py
+++ b/fetch_resume_document.py
@@ -4,7 +4,7 @@ from bson import ObjectId
 MONGO_URL = "mongodb://localhost:27017"
 client = MongoClient(MONGO_URL)
 db = client['devpass']
-resume_collection = db['resume_document']
+resume_collection = db['resumes']
 
 # 이력서 ID(Object)로 이력서 찾기
 def fetch_resume_document(resume_id: str):

--- a/fetch_resume_document.py
+++ b/fetch_resume_document.py
@@ -16,8 +16,7 @@ def extract_user_stacks(resume: dict) -> list[str]:
     stacks = set()
 
     for skill in skills_section:
-        for tech in skill.get("skills", []):
-            stacks.add(tech.strip())
+        stacks.add(skill.strip())
 
     return list(stacks)
 

--- a/recommend_jobs.py
+++ b/recommend_jobs.py
@@ -4,6 +4,8 @@ from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
 from sentence_transformers import SentenceTransformer, util
 
+from fetch_resume_document import fetch_resume_document, convert_resume_to_text, extract_user_stacks
+
 # DATABASE 설정
 DATABASE_URL = "mysql+pymysql://user:password@devpass-db:3306/devpass"
 
@@ -89,3 +91,20 @@ def recommend_jobs(user_stacks, user_resume):
         })
 
     return sorted(recommendations, key=lambda x: float(x['finalScore'].strip('%')), reverse=True)[:2]
+
+def recommend_jobs_by_resume_id(resume_id: str):
+    # 1. 이력서 도큐먼트 조회
+    doc = fetch_resume_document(resume_id)
+    if not doc:
+        raise ValueError("해당 resume_id에 대한 이력서를 찾을 수 없습니다.")
+
+    resume = doc.get("resume")  # 실제 이력서 내용은 "resume" 안에 있음
+
+    # 2. userStacks 추출
+    user_stacks = extract_user_stacks(resume)
+
+    # 3. userResume 텍스트 생성
+    user_resume = convert_resume_to_text(resume)
+
+    # 4. 추천 수행
+    return recommend_jobs(user_stacks, user_resume)

--- a/recommend_jobs.py
+++ b/recommend_jobs.py
@@ -16,7 +16,7 @@ session = Session()
 def fetch_job_postings():
     query = text("""
         SELECT recruitment_id, company_name, position, main_task, qualification, preferred, benefit
-        FROM recruitment
+        FROM recruitments
     """)
     result = session.execute(query).mappings().all()
 
@@ -58,8 +58,8 @@ def recommend_jobs(user_stacks, user_resume):
     for job in job_postings:
         # 채용공고 관련 스택 조회
         job_tech_stacks_query = text("""
-            SELECT s.name FROM recruitment_stack rs
-            JOIN stack s ON rs.stack_id = s.stack_id
+            SELECT s.name FROM recruitment_stacks rs
+            JOIN stacks s ON rs.stack_id = s.stack_id
             WHERE rs.recruitment_id = :recruitment_id
         """)
         job_tech_stacks = [row['name'] for row in session.execute(job_tech_stacks_query, {

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ attrs==24.2.0
 certifi==2024.12.14
 charset-normalizer==3.4.1
 click==8.1.8
+dnspython==2.7.0
 fastapi==0.115.8
 filelock==3.17.0
 fsspec==2025.2.0
@@ -21,8 +22,10 @@ packaging==24.2
 pillow==11.1.0
 pydantic==2.10.6
 pydantic_core==2.27.2
+pymongo==4.12.0
 PyMySQL==1.1.1
 PySocks==1.7.1
+python-dotenv==1.0.1
 PyYAML==6.0.2
 regex==2024.11.6
 requests==2.32.3
@@ -46,5 +49,6 @@ trio-websocket==0.11.1
 typing_extensions==4.12.2
 urllib3==2.2.3
 uvicorn==0.34.0
+webdriver-manager==4.0.2
 websocket-client==1.8.0
 wsproto==1.2.0


### PR DESCRIPTION
## 📖 개요
- 이력서 도메인 API 개발로 인한 AI 기업 매칭 기능 수정

## 💻 작업사항
- 이력서 도메인이 추가됨에 따라 AI 기업 매칭 기능 수정
  - 기존 userResume, userStack으로 받던걸 이력서 id로 받도록 구현
  - 이력서 id로 MongoDB에서 이력서 불러올 수 있도록 로직 추가
  - 불러온 이력서 데이터를 하나의 텍스트 형식으로 변환

## 💡 작성한 이슈 외에 작업한 사항
- 기존 wanted 크롤링의 css selector 변수가 바뀌어서 수정해둠

## ✔️ check list
- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
