### PR TITLE
[feat] 채용공고 필터링을 위한 데이터 분류삽입 로직 구현

### DIFF
--- a/crawler/db_utils.py
+++ b/crawler/db_utils.py
@@ -1,0 +1,15 @@
+from sqlalchemy import text, create_engine
+from sqlalchemy.orm import sessionmaker
+
+DATABASE_URL = "mysql+pymysql://user:password@localhost:3306/devpass"
+engine = create_engine(DATABASE_URL, echo=True)
+Session = sessionmaker(bind=engine)
+session = Session()
+
+def fetch_stack_ids_by_recruitment_id(recruitment_id: int) -> list[int]:
+    result = session.execute(text("""
+        SELECT stack_id
+        FROM recruitment_stacks
+        WHERE recruitment_id = :recruitment_id
+    """), {"recruitment_id": recruitment_id}).fetchall()
+    return [row[0] for row in result]

--- a/crawler/es_utils.py
+++ b/crawler/es_utils.py
@@ -22,7 +22,11 @@ def index_company_to_elasticsearch(company_id, name, category, location, avg_sal
     }
     es.index(index="companies", id=company_id, document=doc)
 
-def index_recruitment_to_elasticsearch(recruitment_id, company_name, position, location, career, main_task, qualification, preferred, benefit, deadline, image_url):
+def index_recruitment_to_elasticsearch(
+    recruitment_id, company_name, position_name, position, location, career,
+    main_task, qualification, preferred, benefit, deadline, image_url,
+    min_career, max_career
+):
     doc = {
         "id": recruitment_id,
         "companyName": company_name,
@@ -36,5 +40,8 @@ def index_recruitment_to_elasticsearch(recruitment_id, company_name, position, l
         "benefit": benefit,
         "deadline": deadline,
         "imageUrl": image_url,
+        "minCareer": min_career,
+        "maxCareer": max_career,
     }
+
     es.index(index="recruitments", id=recruitment_id, document=doc)

--- a/crawler/es_utils.py
+++ b/crawler/es_utils.py
@@ -26,6 +26,7 @@ def index_recruitment_to_elasticsearch(recruitment_id, company_name, position, l
     doc = {
         "id": recruitment_id,
         "companyName": company_name,
+        "positionName": position_name,
         "position": position,
         "location": location,
         "career": career,

--- a/crawler/es_utils.py
+++ b/crawler/es_utils.py
@@ -25,7 +25,7 @@ def index_company_to_elasticsearch(company_id, name, category, location, avg_sal
 def index_recruitment_to_elasticsearch(
     recruitment_id, company_name, position_name, position, location, career,
     main_task, qualification, preferred, benefit, deadline, image_url,
-    min_career, max_career
+    min_career, max_career, stack_ids
 ):
     doc = {
         "id": recruitment_id,
@@ -42,6 +42,7 @@ def index_recruitment_to_elasticsearch(
         "imageUrl": image_url,
         "minCareer": min_career,
         "maxCareer": max_career,
+        "stacks": stack_ids,
     }
 
     es.index(index="recruitments", id=recruitment_id, document=doc)

--- a/crawler/es_utils.py
+++ b/crawler/es_utils.py
@@ -27,12 +27,14 @@ def index_recruitment_to_elasticsearch(
     main_task, qualification, preferred, benefit, deadline, image_url,
     min_career, max_career, stack_ids
 ):
+    location_parsed = parse_location(location)
+
     doc = {
         "id": recruitment_id,
         "companyName": company_name,
         "positionName": position_name,
         "position": position,
-        "location": location,
+        "location": location_parsed,
         "career": career,
         "mainTask": main_task,
         "qualification": qualification,

--- a/crawler/recruitments_crawler.py
+++ b/crawler/recruitments_crawler.py
@@ -154,7 +154,7 @@ try:
             except Exception:
                 pass
 
-            company_name = driver.find_element(By.CSS_SELECTOR, ".JobHeader_JobHeader__Tools__Company__Info__b9P4Y").text
+            company_name = driver.find_element(By.CSS_SELECTOR, ".JobHeader_JobHeader__Tools__Company__Link__NoBQI").text
             location = driver.find_element(By.CSS_SELECTOR, ".JobHeader_JobHeader__Tools__Company__Info__b9P4Y").text
             position_name = WebDriverWait(driver, 10).until(
                 EC.presence_of_element_located((By.CSS_SELECTOR, "h1.wds-jtr30u"))

--- a/crawler/recruitments_crawler.py
+++ b/crawler/recruitments_crawler.py
@@ -10,7 +10,24 @@ from sqlalchemy.orm import sessionmaker
 from crawler.es_utils import index_recruitment_to_elasticsearch
 
 # MySQL 설정
-DATABASE_URL = "mysql+pymysql://user:password@devpass-db:3306/devpass"
+def classify_position(position_name: str) -> str:
+    keyword_map = {
+        "Backend": ["서버", "백엔드", "backend", "API", "spring", "node", "django", "rails"],
+        "Frontend": ["프론트", "프론트엔드", "frontend", "react", "vue", "angular"],
+        "Data": ["데이터", "data", "분석"],
+        "AI": ["AI", "ML", "딥러닝", "머신러닝"],
+        "Mobile": ["android", "ios", "모바일", "앱", "swift", "kotlin"],
+        "DevOps": ["인프라", "devops", "aws", "platform", "k8s", "docker", "클라우드"],
+        "Security": ["보안", "security", "해킹", "취약점"],
+        "QA": ["QA", "테스트", "test", "품질관리"],
+        "PM": ["기획", "PM", "product manager", "PO", "기획자", "프로덕트 매니저"],
+    }
+
+    lowered = position_name.lower()
+    for category, keywords in keyword_map.items():
+        if any(keyword.lower() in lowered for keyword in keywords):
+            return category
+    return "ETC"
 
 engine = create_engine(DATABASE_URL, echo=True)
 Session = sessionmaker(bind=engine)
@@ -44,13 +61,14 @@ def fetch_stacks():
 # 채용공고 저장 및 매핑 함수
 def save_recruitment_with_tech(company_name, location, position, experience, due_date, image_url, details, tech_stacks):
     insert_recruitment_query = text("""
-        INSERT INTO recruitments (company_name, location, position, career, deadline, image_url, main_task, qualification, preferred, benefit)
-        VALUES (:company_name, :location, :position, :career, :deadline, :image_url, :main_task, :qualification, :preferred, :benefit)
+        INSERT INTO recruitments (company_name, location, position_name, position, career, deadline, image_url, main_task, qualification, preferred, benefit)
+        VALUES (:company_name, :location, :position_name, :position, :career, :deadline, :image_url, :main_task, :qualification, :preferred, :benefit)
     """)
 
     session.execute(insert_recruitment_query, {
         "company_name": company_name,
         "location": location,
+        "position_name": position_name,
         "position": position,
         "career": experience,
         "deadline": due_date,
@@ -64,7 +82,14 @@ def save_recruitment_with_tech(company_name, location, position, experience, due
     session.commit()
 
     recruitment_id = session.execute(text("SELECT LAST_INSERT_ID()")).scalar()
-    index_recruitment_to_elasticsearch(recruitment_id, company_name, position, location, experience, details[0] if len(details) > 0 else None, details[1] if len(details) > 1 else None, details[2] if len(details) > 2 else None, details[3] if len(details) > 3 else None, due_date, image_url)
+    index_recruitment_to_elasticsearch(
+        recruitment_id, company_name, position_name, position, location, experience,
+        details[0] if len(details) > 0 else None,
+        details[1] if len(details) > 1 else None,
+        details[2] if len(details) > 2 else None,
+        details[3] if len(details) > 3 else None,
+        due_date, image_url
+    )
 
     combined_text = " ".join(filter(None, details)).lower()
     matched_stack_ids = [tech_id for tech_name, tech_id in tech_stacks.items() if tech_name in combined_text]
@@ -82,7 +107,6 @@ def save_recruitment_with_tech(company_name, location, position, experience, due
                     INSERT INTO recruitment_stack (recruitment_id, stack_id)
                     VALUES (:recruitment_id, :stack_id)
                 """), {"recruitment_id": recruitment_id, "stack_id": stack_id})
-
         session.commit()
         print(f"✅ 기술 스택 매핑 완료: {matched_stack_ids}")
     else:
@@ -117,7 +141,6 @@ try:
         try:
             driver.get(link)
 
-            # '더 보기' 버튼 클릭 시도
             try:
                 button = WebDriverWait(driver, 5).until(
                     EC.element_to_be_clickable(
@@ -126,19 +149,17 @@ try:
                 button.click()
                 time.sleep(2)
             except Exception:
-                pass  # '더 보기' 버튼이 없어도 진행
+                pass
 
-            company_name = driver.find_element(By.CSS_SELECTOR,
-                                               ".JobHeader_JobHeader__Tools__Company__Info__b9P4Y").text
+            company_name = driver.find_element(By.CSS_SELECTOR, ".JobHeader_JobHeader__Tools__Company__Info__b9P4Y").text
             location = driver.find_element(By.CSS_SELECTOR, ".JobHeader_JobHeader__Tools__Company__Info__b9P4Y").text
             position_name = WebDriverWait(driver, 10).until(
                 EC.presence_of_element_located((By.CSS_SELECTOR, "h1.wds-jtr30u"))
             ).text
-            experience = driver.find_elements(By.CSS_SELECTOR, ".JobHeader_JobHeader__Tools__Company__Info__b9P4Y")[
-                -1].text
+            position = classify_position(position_name)
+            experience = driver.find_elements(By.CSS_SELECTOR, ".JobHeader_JobHeader__Tools__Company__Info__b9P4Y")[-1].text
             due_date = driver.find_element(By.CSS_SELECTOR, ".JobDueTime_JobDueTime__yvhtg span").text
 
-            # ✅ 이미지 URL 추출
             try:
                 image_element = driver.find_element(By.CSS_SELECTOR, ".JobCard_JobCard__thumb__iOtFn img")
                 image_url = image_element.get_attribute("src")
@@ -146,17 +167,12 @@ try:
                 image_url = None
                 print("⚠️ 이미지 URL을 찾을 수 없음.")
 
-            # 상세 내용 추출
-            job_detail_wrapper = driver.find_element(By.CSS_SELECTOR,
-                                                     ".JobDescription_JobDescription__paragraph__wrapper__WPrKC")
-            paragraphs = job_detail_wrapper.find_elements(By.CSS_SELECTOR,
-                                                          ".JobDescription_JobDescription__paragraph__87w8I")
-            details = [p.find_element(By.CSS_SELECTOR, "span").text.replace("\n", " ").strip() for p in paragraphs if
-                       p.text.strip()]
+            job_detail_wrapper = driver.find_element(By.CSS_SELECTOR, ".JobDescription_JobDescription__paragraph__wrapper__WPrKC")
+            paragraphs = job_detail_wrapper.find_elements(By.CSS_SELECTOR, ".JobDescription_JobDescription__paragraph__87w8I")
+            details = [p.find_element(By.CSS_SELECTOR, "span").text.replace("\n", " ").strip() for p in paragraphs if p.text.strip()]
 
-            save_recruitment_with_tech(company_name, location, position_name, experience, due_date, image_url, details,
-                                       tech_stacks)
-            print(f"🎉 채용공고 저장 완료: {company_name} - {position_name}")
+            save_recruitment_with_tech(company_name, location, position_name, position, experience, due_date, image_url, details, tech_stacks)
+            print(f"🎉 채용공고 저장 완료: {company_name} - {position_name} ({position})")
 
         except Exception as e:
             print(f"❌ 에러 발생 ({link}): {e}")

--- a/crawler/recruitments_crawler.py
+++ b/crawler/recruitments_crawler.py
@@ -8,6 +8,7 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
 
 from crawler.es_utils import index_recruitment_to_elasticsearch
+from crawler.utils import parse_career_range
 
 # MySQL 설정
 def classify_position(position_name: str) -> str:
@@ -88,7 +89,8 @@ def save_recruitment_with_tech(company_name, location, position, experience, due
         details[1] if len(details) > 1 else None,
         details[2] if len(details) > 2 else None,
         details[3] if len(details) > 3 else None,
-        due_date, image_url
+        due_date, image_url,
+        min_career, max_career
     )
 
     combined_text = " ".join(filter(None, details)).lower()
@@ -157,7 +159,9 @@ try:
                 EC.presence_of_element_located((By.CSS_SELECTOR, "h1.wds-jtr30u"))
             ).text
             position = classify_position(position_name)
-            experience = driver.find_elements(By.CSS_SELECTOR, ".JobHeader_JobHeader__Tools__Company__Info__b9P4Y")[-1].text
+            experience = driver.find_elements(By.CSS_SELECTOR, ".JobHeader_JobHeader__Tools__Company__Info__b9P4Y")[
+                -1].text
+            min_career, max_career = parse_career_range(experience)
             due_date = driver.find_element(By.CSS_SELECTOR, ".JobDueTime_JobDueTime__yvhtg span").text
 
             try:

--- a/crawler/utils.py
+++ b/crawler/utils.py
@@ -1,0 +1,20 @@
+import re
+
+def parse_career_range(career_str: str) -> tuple[int, int]:
+    if not career_str or "신입" in career_str:
+        min_career = 0
+        max_career_match = re.search(r'(\d+)', career_str)
+        max_career = int(max_career_match.group(1)) if max_career_match else 0
+        return min_career, max_career
+
+    range_match = re.search(r'(\d+)[년\s]*[-~][\s]*(\d+)', career_str)
+    single_match = re.search(r'(\d+)', career_str)
+
+    if range_match:
+        return int(range_match.group(1)), int(range_match.group(2))
+    elif "이상" in career_str and single_match:
+        return int(single_match.group(1)), 99
+    elif single_match:
+        year = int(single_match.group(1))
+        return year, year
+    return 0, 99

--- a/crawler/utils.py
+++ b/crawler/utils.py
@@ -18,3 +18,13 @@ def parse_career_range(career_str: str) -> tuple[int, int]:
         year = int(single_match.group(1))
         return year, year
     return 0, 99
+
+def parse_location(location_str):
+    parts = location_str.strip().split()
+    region = parts[0] if len(parts) > 0 else None
+    district = parts[1] if len(parts) > 1 else None
+
+    return {
+        "region": region,
+        "district": district,
+    }


### PR DESCRIPTION
## 📖 개요
- 채용공고 필터링을 위한 데이터 분류삽입 로직
- 필터링 로직

## 💻 작업사항
- 포지션 필터링
  - 채용공고 이름에 포지션이 적혀있기 때문에, dictionary를 만들어 value에 해당하는 단어가 들어간 채용공고는 key에 대한 포지션 값을 갖을 수 있게 로직 추가
- 경력 필터링
  - 경력이 대부분 n년 이상, n년~m년 이런 식으로 되어있기 때문에 저런 형태를 min, max로 나누어 n과 m을 분리 (이상, 이하를 다 검색할 수 있도록)
- 기술 스택 필터링
  - 기존에 있던 기술 스택 테이블을 이용하여 es에 기술 스택을 인덱싱
- 지역 필터링
  - 지역이 oo시 oo구 <- 이런식으로 나타나 있기 때문에 region, district로 구분하여 es에 인덱싱
  - 서울시만 검색할 수도 있고, 서울시 oo구처럼 구체적으로도 검색 가능하도록 인덱싱

## 💡 작성한 이슈 외에 작업한 사항
- x

## ✔️ check list
- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
