### PR TITLE
[feat] 채용공고 크롤링 시, 해당 기업의 연봉, 직원 수가 함께 인덱싱되도록 추가

### DIFF
--- a/crawler/db_utils.py
+++ b/crawler/db_utils.py
@@ -1,5 +1,6 @@
 from sqlalchemy import text, create_engine
 from sqlalchemy.orm import sessionmaker
+import re
 
 DATABASE_URL = "mysql+pymysql://user:password@localhost:3306/devpass"
 engine = create_engine(DATABASE_URL, echo=True)
@@ -13,3 +14,26 @@ def fetch_stack_ids_by_recruitment_id(recruitment_id: int) -> list[int]:
         WHERE recruitment_id = :recruitment_id
     """), {"recruitment_id": recruitment_id}).fetchall()
     return [row[0] for row in result]
+
+def extract_number(text):
+    match = re.search(r"\d+", text.replace(",", ""))
+    return int(match.group()) if match else None
+
+def fetch_additional_company_info(company_name: str):
+    result = session.execute(text("""
+        SELECT id, category, location, avg_salary, new_hire_avg_salary, employee_count
+        FROM companies
+        WHERE name = :company_name
+    """), {"company_name": company_name}).mappings().first()
+
+    if not result:
+        raise Exception(f"회사 정보 없음: {company_name}")
+
+    return {
+        "company_id": result["id"],
+        "category": result["category"],
+        "location": result["location"],
+        "avg_salary": result["avg_salary"],
+        "new_hire_avg_salary": result["new_hire_avg_salary"],
+        "employee_count": result["employee_count"],
+    }

--- a/crawler/es_utils.py
+++ b/crawler/es_utils.py
@@ -1,5 +1,7 @@
 from elasticsearch import Elasticsearch
 
+from crawler.utils import parse_location, parse_salary_string
+
 es = Elasticsearch(
     "http://devpass-elasticsearch:9200",
     headers={
@@ -23,14 +25,18 @@ def index_company_to_elasticsearch(company_id, name, category, location, avg_sal
     es.index(index="companies", id=company_id, document=doc)
 
 def index_recruitment_to_elasticsearch(
-    recruitment_id, company_name, position_name, position, location, career,
-    main_task, qualification, preferred, benefit, deadline, image_url,
-    min_career, max_career, stack_ids
+    recruitment_id, company_id, company_name,
+    position_name, position, location, career,
+    main_task, qualification, preferred, benefit,
+    deadline, image_url, min_career, max_career, stack_ids,
+    new_hire_avg_salary=None, employee_count=None
 ):
     location_parsed = parse_location(location)
+    new_hire_avg_salary_int = parse_salary_string(new_hire_avg_salary)
 
     doc = {
         "id": recruitment_id,
+        "companyId": company_id,
         "companyName": company_name,
         "positionName": position_name,
         "position": position,
@@ -45,6 +51,8 @@ def index_recruitment_to_elasticsearch(
         "minCareer": min_career,
         "maxCareer": max_career,
         "stacks": stack_ids,
+        "newHireAvgSalary": new_hire_avg_salary_int,
+        "employeeCount": employee_count
     }
 
     es.index(index="recruitments", id=recruitment_id, document=doc)

--- a/crawler/recruitments_crawler.py
+++ b/crawler/recruitments_crawler.py
@@ -104,15 +104,26 @@ def save_recruitment_with_tech(company_name, location, position_name, position, 
 
     min_career, max_career = parse_career_range(experience)
     stack_ids = matched_stack_ids
+
     index_recruitment_to_elasticsearch(
-        recruitment_id, company_name, position_name, position, location, experience,
-        details[0] if len(details) > 0 else None,
-        details[1] if len(details) > 1 else None,
-        details[2] if len(details) > 2 else None,
-        details[3] if len(details) > 3 else None,
-        due_date, image_url,
-        min_career, max_career,
-        stack_ids
+        recruitment_id,
+        company_id=company_info["company_id"],
+        company_name=company_name,
+        position_name=position_name,
+        position=position,
+        location=location,
+        career=experience,
+        main_task=details[0] if len(details) > 0 else None,
+        qualification=details[1] if len(details) > 1 else None,
+        preferred=details[2] if len(details) > 2 else None,
+        benefit=details[3] if len(details) > 3 else None,
+        deadline=due_date,
+        image_url=image_url,
+        min_career=min_career,
+        max_career=max_career,
+        stack_ids=stack_ids,
+        new_hire_avg_salary=company_info["new_hire_avg_salary"],
+        employee_count=company_info["employee_count"]
     )
 
 try:

--- a/crawler/utils.py
+++ b/crawler/utils.py
@@ -28,3 +28,8 @@ def parse_location(location_str):
         "region": region,
         "district": district,
     }
+
+def parse_salary_string(salary_str: str) -> int:
+    if not salary_str:
+        return 0
+    return int(salary_str.replace(",", "").replace("만원", "").strip())


### PR DESCRIPTION
## 📖 개요
- 채용공고 크롤링 시, 해당 기업의 연봉, 직원 수가 함께 인덱싱되도록 추가

## 💻 작업사항
- 기존 company 데이터에서 연봉, 직원 수를 가져와 ES에 함께 인덱싱하도록 수정 (검색시 필터링을 위해)

## 💡 작성한 이슈 외에 작업한 사항
- 기존 연봉이 string 값으로 저장되기때문에 필터링을 위해 string -> long으로 바꾸는 util 함수 추가

## ✔️ check list
- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
